### PR TITLE
Laravel 5 fixes

### DIFF
--- a/Http/Controllers/Admin/AdminBaseController.php
+++ b/Http/Controllers/Admin/AdminBaseController.php
@@ -1,7 +1,9 @@
 <?php namespace Modules\Core\Http\Controllers\Admin;
 
-class AdminBaseController
-{
+use Illuminate\Routing\Controller;
+
+class AdminBaseController extends Controller {
+
     public function __construct()
     {
     }

--- a/Http/Controllers/BasePublicController.php
+++ b/Http/Controllers/BasePublicController.php
@@ -1,8 +1,9 @@
 <?php namespace Modules\Core\Http\Controllers;
 
+use Illuminate\Routing\Controller;
 use Modules\Core\Contracts\Setting;
 
-abstract class BasePublicController
+abstract class BasePublicController extends Controller
 {
     /**
      * @var string The active theme name

--- a/Providers/CoreServiceProvider.php
+++ b/Providers/CoreServiceProvider.php
@@ -13,6 +13,7 @@ use Modules\Core\Services\Composer;
 use Modules\Menu\Entities\Menuitem;
 use Modules\Menu\Repositories\Cache\CacheMenuItemDecorator;
 use Modules\Menu\Repositories\Eloquent\EloquentMenuItemRepository;
+use Pingpong\Modules\Module;
 
 class CoreServiceProvider extends ServiceProvider
 {
@@ -163,6 +164,9 @@ class CoreServiceProvider extends ServiceProvider
             $modules = $app['modules']->enabled();
             $loader = AliasLoader::getInstance();
             foreach ($modules as $moduleName => $module) {
+
+                $this->registerViewNamespace($module);
+
                 if ($aliases = $module->get('aliases')) {
                     foreach ($aliases as $aliasName => $aliasClass) {
                         $loader->alias($aliasName, $aliasClass);
@@ -170,5 +174,17 @@ class CoreServiceProvider extends ServiceProvider
                 }
             }
         });
+    }
+
+    /**
+     * Register the view namespaces for the modules
+     * @param Module $module
+     */
+    protected function registerViewNamespace(Module $module)
+    {
+        $this->app['view']->addNamespace(
+            $module->getName(),
+            $module->getPath() . '/Resources/views'
+        );
     }
 }


### PR DESCRIPTION
- Fixed installer: use `vendor:publish` instead of `migrate --package`
- Controllers should extend Illuminate\Routing\Controller
- Register view namespaces for all modules, so user::, core::, dashboard:: can still be used and point to the right folder.

(WIP)