### PR TITLE
Add support for camelcase module name in AdminSidebar

### DIFF
--- a/Sidebar/AdminSidebar.php
+++ b/Sidebar/AdminSidebar.php
@@ -43,7 +43,7 @@ class AdminSidebar implements Sidebar, ShouldCache
     public function build()
     {
         foreach ($this->modules->enabled() as $module) {
-            $name = studly_case($module->getName());
+            $name = studly_case($module->get('name'));
             $class = 'Modules\\' . $name . '\\Sidebar\\SidebarExtender';
 
             if (class_exists($class)) {


### PR DESCRIPTION
Not sure if studly_case is needed since pinpong modules work of PSR4, but for the sake of when and if it allows hypens, dashesh in name there will be no need to change again.