### PR TITLE
Adding support for custom environment file locations

### DIFF
--- a/Providers/CoreServiceProvider.php
+++ b/Providers/CoreServiceProvider.php
@@ -61,13 +61,15 @@ class CoreServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('asgard.isInstalled', function ($app) {
+            $envFileLocation = "{$app->environmentPath()}/{$app->environmentFile()}";
+
             try {
                 $hasTable = Schema::hasTable('setting__settings');
             } catch (\Exception $e) {
                 $hasTable = false;
             }
 
-            return $app['files']->isFile(base_path('.env')) && $hasTable;
+            return $app['files']->isFile($envFileLocation) && $hasTable;
         });
 
         $this->registerCommands();


### PR DESCRIPTION
Adds support for custom environment file locations, which can be added by overriding the `DetectEnvironment` bootstrapper and changing the bootstrappers on the Http Kernel and Console Kernel