### PR TITLE
Macro Dropdown select i18 & normal

### DIFF
--- a/macros.php
+++ b/macros.php
@@ -90,6 +90,48 @@ Form::macro('i18nCheckbox', function ($name, $title, ViewErrorBag $errors, $lang
     return $string;
 });
 
+/**
+ * Add a dropdown select field
+ * @param string $name The field name
+ * @param string $title The field title
+ * @param object $errors The laravel errors object
+ * @param string $lang the language of the field
+ * @param array $choice The choice of the select
+ * @param null|array $object The entity of the field
+ */
+Form::macro('i18nDropDown', function ($name, $title, ViewErrorBag $errors, $lang, array $choice, $object = null, array $options = []) {
+    if (array_key_exists("multiple", $options)) {
+        $nameForm = "{$lang}[$name][]";
+    } else {
+        $nameForm = "{$lang}[$name]";
+    }
+
+    $string  = "<div class='form-group dropdown" . ($errors->has($lang . '.' . $name) ? ' has-error' : '') . "'>";
+    $string .= "<label for='$nameForm'>$title</label>";
+
+    if (is_object($object)) {
+        $currentData = $object->hasTranslation($lang) ? $object->translate($lang)->{$name} : '';
+    } else {
+        $currentData = false;
+    }
+
+    /* Bootstrap default class */
+    $array_option = ['class' => 'form-control'];
+
+    if (array_key_exists("class", $options)) {
+        $array_option = ['class' => $array_option['class'] . ' ' . $options['class']];
+        unset($options['class']);
+    }
+
+    $options = array_merge($array_option, $options);
+
+    $string .= Form::select($nameForm, $choice, Input::old($nameForm, $currentData), $options);
+    $string .= $errors->first("{$lang}.{$name}", '<span class="help-block">:message</span>');
+    $string .= "</div>";
+
+    return $string;
+});
+
 /*
 |--------------------------------------------------------------------------
 | Standard fields
@@ -164,6 +206,48 @@ Form::macro('normalCheckbox', function ($name, $title, ViewErrorBag $errors, $ob
     $string .= $title;
     $string .= $errors->first($name, '<span class="help-block">:message</span>');
     $string .= "</label>";
+    $string .= "</div>";
+
+    return $string;
+});
+
+/**
+ * Add a dropdown select field
+ * @param string $name The field name
+ * @param string $title The field title
+ * @param object $errors The laravel errors object
+ * @param array $choice The choice of the select
+ * @param null|array $object The entity of the field
+ */
+Form::macro('normalDropDown', function ($name, $title, ViewErrorBag $errors, array $choice, $object = null, array $options = []) {
+    if (array_key_exists("multiple", $options)) {
+        $nameForm = $name . '[]';
+    } else {
+        $nameForm = $name;
+    }
+
+    $string = "<div class='form-group dropdown" . ($errors->has($name) ? ' has-error' : '') . "'>";
+    $string .= "<label for='$nameForm'>$title</label>";
+
+    if (is_object($object)) {
+        $currentData = isset($object->$name) ? $object->$name : '';
+    } else {
+        $currentData = false;
+    }
+
+    /* Bootstrap default class */
+    $array_option = ['class' => 'form-control'];
+
+    if (array_key_exists("class", $options)) {
+        $array_option = ['class' => $array_option['class'] . ' ' . $options['class']];
+        unset($options['class']);
+    }
+
+    $options = array_merge($array_option, $options);
+
+    //$string .= Form::select($nameForm, $choice, $currentData, $options), Input:old($nameForm, $choice, $currentData, $options);
+    $string .= Form::select($nameForm, $choice, Input::old($nameForm, $currentData), $options);
+    $string .= $errors->first($name, '<span class="help-block">:message</span>');
     $string .= "</div>";
 
     return $string;

--- a/macros.php
+++ b/macros.php
@@ -245,7 +245,6 @@ Form::macro('normalDropDown', function ($name, $title, ViewErrorBag $errors, arr
 
     $options = array_merge($array_option, $options);
 
-    //$string .= Form::select($nameForm, $choice, $currentData, $options), Input:old($nameForm, $choice, $currentData, $options);
     $string .= Form::select($nameForm, $choice, Input::old($nameForm, $currentData), $options);
     $string .= $errors->first($name, '<span class="help-block">:message</span>');
     $string .= "</div>";


### PR DESCRIPTION
Macro drop down select field.

How to use for **i18nDropDown**

`{!! Form::i18nDropDown($name, $title, $errors, $lang, $choice, $object, $options]) !!}
`

Which give for instance

`{!! Form::i18nDropDown(‘test’, ‘test’, $errors, $lang, [1,2,3], $object) !!}
`

Or for multiple select:

`{!! Form::i18nDropDown(‘test’, ‘test’, $errors, $lang, [1,2,3], $object, ['multiple' => 'multiple', 'class' => 'select-multiple']) !!}`

Same for **normalDropDown**

`{!! Form::normalDropDown(‘test’, ‘test’, $errors, [1,2,3], $object) !!}`

Or for multiple select:

`{!! Form::normalDropDown(‘test’, ‘test’, $errors, ['1,2,3], $object, ['multiple' => 'multiple', 'class' => 'select-multiple']) !!}`

Don’t know if normalDropDown or normalSelect was the most suitable name, what do you think ?

