### PR TITLE
[BC] Honor laravel custom error message language structure

### DIFF
--- a/Internationalisation/BaseFormRequest.php
+++ b/Internationalisation/BaseFormRequest.php
@@ -56,7 +56,7 @@ abstract class BaseFormRequest extends FormRequest
             foreach ($this->container->call([$this, 'translationRules']) as $attribute => $rule) {
                 $key = $localeKey . '.' . $attribute;
                 $rules[$key] = $rule;
-                $attributes[$key] = trans($translationsAttributesKey . $attribute);
+                $attributes[$key] = trans($translationsAttributesKey . $attribute . '.' . $rule);
             }
 
             foreach ($this->container->call([$this, 'translationMessages']) as $attributeAndRule => $message) {


### PR DESCRIPTION
Currently you can only have 1 rule message for all rules.
As specified in https://laravel.com/docs/5.1/validation#custom-error-messages you can have many rules under one key.

Unfortunately this one is BC.