### PR TITLE
Shortcode support

### DIFF
--- a/Http/Middleware/ShortcodeMiddleware.php
+++ b/Http/Middleware/ShortcodeMiddleware.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Modules\Boats\Http\Middleware;
+
+use Closure;
+
+class ShortcodeMiddleware {
+
+    /**
+     * Intercept a response to replace shortcodes
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+
+        $shotcodes = config('asgard.core.shortcodes');
+
+        foreach ($shotcodes as $shortcode => $options) {
+            $response->setContent(
+                str_replace("[$shortcode]", view($options['view'], $options['data'])->render(), $response->getContent())
+            );
+        }
+
+    	return $response;
+    }
+    
+}


### PR DESCRIPTION
This new middleware will replace any shortcode configured in asgard.core.shortcodes.php.

Here is an example to show you how it works : 

Example of configuration to put in asgard.core.shortcodes.php

'contact' => [
    'view' => 'contact',
    'data' => []
]

"contact" will be the shortcode to be inserted as "[contact]", in a page content for example.
"view" will be the view to replace the shortcode.
"data" can be used to insert some data into the view.
