### PR TITLE
Shortcode support

### DIFF
--- a/Http/Middleware/ShortcodeMiddleware.php
+++ b/Http/Middleware/ShortcodeMiddleware.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Modules\Core\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class ShortcodeMiddleware
+{
+    /**
+     * Intercept a response to replace shortcodes
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+
+        // Get defined shortcodes from the config file
+        $shotcodesDefinitions = config('asgard.core.shortcodes', []);
+
+        foreach ($shotcodesDefinitions as $shortcodeName => $options) {
+
+            // Search for shortcodes in the response's content
+            if (preg_match("/\[$shortcodeName.*\]/", $response->getContent(), $shortcodes)) {
+                foreach ($shortcodes as $shortcode) {
+
+                    // Search for parameters
+                    preg_match('/\w+=&quot;.*&quot;/', $shortcode, $rawParameters);
+
+                    if (! empty($rawParameters)) {
+                        $parameters = new Request();
+
+                        // Parse every parameters and put them in a Request object
+                        foreach ($rawParameters as $rawParameter) {
+                            list($name, $value) = explode('=', $rawParameter);
+
+                            $parameters->query->set($name, trim($value, '&quot;'));
+                        }
+
+                        if (array_key_exists('callback', $options)) {
+                            // Call a function to interpret parameters and get the results as an array
+                            $results = call_user_func($options['callback'], $parameters);
+                        }
+                    } else {
+                        if (array_key_exists('callback', $options)) {
+                            // Call a function to interpret parameters and get the results as an array
+                            $results = call_user_func($options['callback']);
+                        }
+                    }
+
+                    if (isset($options['view'])) {
+                        $view = view($options['view'], compact('results'))->render();
+                    } else {
+                        // If there is no view configured, it assumes that the callback himself is rendering the view
+                        $view = $results;
+                    }
+
+                    // Replace the shortcode by the corresponfing view and datas
+                    $response->setContent(preg_replace("/\[$shortcodeName.*\]/", $view, $response->getContent()));
+                }
+            }
+        }
+
+        return $response;
+    }
+
+}


### PR DESCRIPTION
I finally found some time to propose you a more complete version of my shortcode support.

This middleware allows to configure shortcodes using a config file. A shortcode like "[exemple]" will call a function and replace it by a view.
This can be useful to allow users to easily insert advanced functionality when they are creating page on their website for example.

Configuration example :

return [
    // This [contact] shortcode will be replaced by a view
    'contact' =>  [
        'view' => 'contact'
    ],
    // This one will call Modules\Boats\Entities\Boat::prepareResult and display it's result in the "boat.result-content" view
    'boats' => [
        'view' => 'boat.result-content',
        'callback' => [Modules\Boats\Entities\Boat::class, 'prepareResult']
    ],
    'last-minute' => [
        'view' => 'boat.result-content',
        'callback' => [Modules\Boats\Entities\Boat::class, 'prepareOffers']
    ],
    // In this example, a rendering function is called, so no view is needed
    'sitemap' => [
        'callback' => 'generateSitemap'
    ]
];

To be enabled, "asgard.page.config.php" needs to configured that way :

`'middleware' => [
     'shortcode' => \Modules\Core\Http\Middleware\ShortcodeMiddleware::class
]`
