### PR TITLE
Fixed sidebar url to url path for onBackend()

### DIFF
--- a/Providers/SidebarServiceProvider.php
+++ b/Providers/SidebarServiceProvider.php
@@ -28,8 +28,8 @@ class SidebarServiceProvider extends ServiceProvider
 
     private function onBackend()
     {
-        $url = $this->request->url();
-        if (str_contains($url, config('asgard.core.core.admin-prefix'))) {
+        $path = $this->request->path();
+        if (str_contains($path, config('asgard.core.core.admin-prefix'))) {
             return true;
         }
         return false;

--- a/Providers/SidebarServiceProvider.php
+++ b/Providers/SidebarServiceProvider.php
@@ -28,8 +28,8 @@ class SidebarServiceProvider extends ServiceProvider
 
     private function onBackend()
     {
-        $path = $this->request->path();
-        if (str_contains($path, config('asgard.core.core.admin-prefix'))) {
+        $segment = $this->request->segment(1);
+        if (str_contains($segment, config('asgard.core.core.admin-prefix'))) {
             return true;
         }
         return false;


### PR DESCRIPTION
Instead of searching the whole url, it's better to search only in the url path.

For example if you site is called www.bla.com and the admin-prefix is set to 'bla', then onBackend thinks he's on the backend and all the translation will be loaded on the frontpage. But www.bla.com/bla is the backend side.
