### PR TITLE
Allow another database then mysql while running the installation script

### DIFF
--- a/Console/Installers/Scripts/ConfigureDatabase.php
+++ b/Console/Installers/Scripts/ConfigureDatabase.php
@@ -47,14 +47,14 @@ class ConfigureDatabase implements SetupScript
         $connected = false;
 
         while (! $connected) {
-            $type = $this->askDatabaseDriver();
+            $driver = $this->askDatabaseDriver();
             $host = $this->askDatabaseHost();
-            $port = $this->askDatabasePort($type);
+            $port = $this->askDatabasePort($driver);
             $name = $this->askDatabaseName();
             $user = $this->askDatabaseUsername();
             $password = $this->askDatabasePassword();
 
-            $this->setLaravelConfiguration($name, $user, $password, $host);
+            $this->setLaravelConfiguration($driver, $name, $port, $user, $password, $host);
 
             if ($this->databaseConnectionIsValid()) {
                 $connected = true;
@@ -144,7 +144,7 @@ class ConfigureDatabase implements SetupScript
      * @param $user
      * @param $password
      */
-    protected function setLaravelConfiguration($driver, $port, $name, $user, $password, $host)
+    protected function setLaravelConfiguration($driver, $name, $port, $user, $password, $host)
     {
         $this->config['database.default'] = $driver;
         $this->config['database.connections.'.$driver.'.host'] = $host;

--- a/Console/Installers/Scripts/ConfigureDatabase.php
+++ b/Console/Installers/Scripts/ConfigureDatabase.php
@@ -47,12 +47,11 @@ class ConfigureDatabase implements SetupScript
         $connected = false;
 
         while (! $connected) {
+            $type = $this->askDatabaseDriver();
             $host = $this->askDatabaseHost();
-
+            $port = $this->askDatabasePort($type);
             $name = $this->askDatabaseName();
-
             $user = $this->askDatabaseUsername();
-
             $password = $this->askDatabasePassword();
 
             $this->setLaravelConfiguration($name, $user, $password, $host);
@@ -72,11 +71,30 @@ class ConfigureDatabase implements SetupScript
     /**
      * @return string
      */
+    protected function askDatabaseDriver()
+    {
+        $driver = $this->command->ask('Enter your database driver (e.g. mysql, pgsql)', 'mysql');
+        return $driver;
+    }
+
+    
+    /**
+     * @return string
+     */
     protected function askDatabaseHost()
     {
         $host = $this->command->ask('Enter your database host', 'localhost');
 
         return $host;
+    }
+    
+    /**
+     * @return string
+     */
+    protected function askDatabasePort($driver)
+    {
+        $port = $this->command->ask('Enter your database port', $this->config['database.connections.'.$driver.'.port']);
+        return $port;
     }
 
     /**
@@ -126,12 +144,14 @@ class ConfigureDatabase implements SetupScript
      * @param $user
      * @param $password
      */
-    protected function setLaravelConfiguration($name, $user, $password, $host)
+    protected function setLaravelConfiguration($driver, $port, $name, $user, $password, $host)
     {
-        $this->config['database.connections.mysql.host'] = $host;
-        $this->config['database.connections.mysql.database'] = $name;
-        $this->config['database.connections.mysql.username'] = $user;
-        $this->config['database.connections.mysql.password'] = $password;
+        $this->config['database.default'] = $driver;
+        $this->config['database.connections.'.$driver.'.host'] = $host;
+        $this->config['database.connections.'.$driver.'.port'] = $port;
+        $this->config['database.connections.'.$driver.'.database'] = $name;
+        $this->config['database.connections.'.$driver.'.username'] = $user;
+        $this->config['database.connections.'.$driver.'.password'] = $password;
     }
 
     /**

--- a/Console/Installers/Scripts/ConfigureDatabase.php
+++ b/Console/Installers/Scripts/ConfigureDatabase.php
@@ -140,7 +140,7 @@ class ConfigureDatabase implements SetupScript
     }
 
     /**
-     * @param $driver 
+     * @param $driver
      * @param $name
      * @param $port
      * @param $user

--- a/Console/Installers/Scripts/ConfigureDatabase.php
+++ b/Console/Installers/Scripts/ConfigureDatabase.php
@@ -54,7 +54,7 @@ class ConfigureDatabase implements SetupScript
             $user = $this->askDatabaseUsername();
             $password = $this->askDatabasePassword();
 
-            $this->setLaravelConfiguration($driver, $name, $port, $user, $password, $host);
+            $this->setLaravelConfiguration($driver, $host, $port, $name, $user, $password);
 
             if ($this->databaseConnectionIsValid()) {
                 $connected = true;
@@ -140,11 +140,13 @@ class ConfigureDatabase implements SetupScript
     }
 
     /**
+     * @param $driver 
      * @param $name
+     * @param $port
      * @param $user
      * @param $password
      */
-    protected function setLaravelConfiguration($driver, $name, $port, $user, $password, $host)
+    protected function setLaravelConfiguration($driver, $host, $port, $name, $user, $password)
     {
         $this->config['database.default'] = $driver;
         $this->config['database.connections.'.$driver.'.host'] = $host;

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": ">=5.6",
     "composer/installers": "~1.0",
-    "nwidart/laravel-modules": "~0.11",
+    "nwidart/laravel-modules": "~1.0",
     "laravelcollective/html": "~5.3.0",
     "laracasts/presenter": "~0.2",
     "dimsav/laravel-translatable": "~6.0",


### PR DESCRIPTION
With this changes, it's possible to define another database driver.
It's now also possible to change the port.

I updated also the composer.json to keep in sync with: https://github.com/Idavoll/Core/blob/2.0/composer.json